### PR TITLE
Pure example comment fix

### DIFF
--- a/examples/Pure/Dropdown.elm
+++ b/examples/Pure/Dropdown.elm
@@ -1,41 +1,36 @@
-module Pure.Dropdown exposing 
-    (Context, Config, view)
-{- a Dropdown component that manages its own state
--}
+module Pure.Dropdown exposing (Context, Config, view)
+{- a stateless Dropdown component -}
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onWithOptions)
 import Json.Decode as Json
-
 import Styles.Styles as Styles
 
 
-
 -- MODEL
-
 {- Context type alias
-this is dynamic stuff - may change in each update cylce
-this is not managed by the dropdown, but passed in from parent
-kind of like props (including callbacks) in react
--} 
+   this is dynamic stuff - may change in each update cycle
+   this is not managed by the dropdown, but passed in from parent
+   kind of like props (including callbacks) in react
+-}
 type alias Context =
     { selectedItem : Maybe String
     , isOpen : Bool
     }
 
-{- Config is the static stuff, that won't change during life cylce
-Like functions and message constructors
-Also transparent, because this is also owned by parent
+{- Config is the static stuff, that won't change during life cycle
+   Like functions and message constructors
+   Also transparent, because this is also owned by parent
 -}
 type alias Config msg =
     { defaultText : String
-    , clickedMsg : msg 
-    , itemPickedMsg : (String -> msg)
+    , clickedMsg : msg
+    , itemPickedMsg : String -> msg
     }
 
 
--- VIEW
 
+-- VIEW
 
 
 view : Config msg -> Context -> List String -> Html msg
@@ -43,53 +38,55 @@ view config context data =
     let
         mainText =
             context.selectedItem
-            |> Maybe.withDefault config.defaultText
+                |> Maybe.withDefault config.defaultText
 
         displayStyle =
             if context.isOpen then
-                ("display", "block")
+                ( "display", "block" )
             else
-                ("display", "none")
+                ( "display", "none" )
 
         mainAttr =
             case data of
-                [] -> 
+                [] ->
                     [ style <| Styles.dropdownDisabled ++ Styles.dropdownInput
-                    ] 
+                    ]
 
                 _ ->
                     [ style Styles.dropdownInput
-                    , onClick config.clickedMsg 
-                    ] 
-
+                    , onClick config.clickedMsg
+                    ]
     in
-        div 
+        div
             [ style Styles.dropdownContainer ]
-            [ p 
+            [ p
                 mainAttr
-                [ span [ style Styles.dropdownText ] [ text mainText ] 
+                [ span [ style Styles.dropdownText ] [ text mainText ]
                 , span [] [ text "▾" ]
                 ]
-            , ul 
+            , ul
                 [ style <| displayStyle :: Styles.dropdownList ]
                 (List.map (viewItem config) data)
             ]
-            
-    
+
+
 viewItem : Config msg -> String -> Html msg
 viewItem config item =
-    li 
+    li
         [ style Styles.dropdownListItem
         , onClick <| config.itemPickedMsg item
         ]
         [ text item ]
 
 
+
 -- helper to cancel click anywhere
+
+
 onClick : msg -> Attribute msg
 onClick message =
-    onWithOptions 
-        "click" 
+    onWithOptions
+        "click"
         { stopPropagation = True
         , preventDefault = False
         }


### PR DESCRIPTION
This is a fantastic repo and blogpost! I got a lot of value out of looking at it, and when I saw this comment error (saying that the pure dropdown manages its own state), it stalled me for just a small moment. My vim config changed a bit of whitespace, but mostly this PR fixes a couple tiny comment typos.